### PR TITLE
[Add] TODOリクエスト機能の追加

### DIFF
--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -58,7 +58,7 @@ class AdminCog(commands.Cog):
                 value = stdout.getvalue()
                 embed = discord.Embed(
                     title="Error",
-                    descriription=f"エラーが発生しました。コードを確認してください。\ntraceback:```py\n{value}{traceback.format_exc()}\n```"
+                    description=f"エラーが発生しました。コードを確認してください。\ntraceback:```py\n{value}{traceback.format_exc()}\n```"
                 )
                 await ctx.send(embed=embed)
             else:

--- a/cogs/todo.py
+++ b/cogs/todo.py
@@ -4,6 +4,8 @@ import numpy
 import textwrap
 
 
+REACTIONS = ["👍", "👎"]
+
 class TODOCog(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
@@ -59,18 +61,18 @@ class TODOCog(commands.Cog):
             msg += f"{todo}\n"
         msg += "\nTODOに追加しますか？"
         msg = await message.channel.send(msg)
-        await msg.add_reaction("👍")
-        await msg.add_reaction("👎")
+        await msg.add_reaction(REACTIONS[0])
+        await msg.add_reaction(REACTIONS[1])
 
-        def check(reac, user):
+        def check(reaction, user):
             if not user == message.author:
                 return False
-            if not str(reac.emoji) in ["👍", "👎"]:
+            if not str(reaction.emoji) in REACTIONS:
                 return False
             return True
 
-        reac, _ = await self.bot.wait_for("reaction_add", check=check)
-        if str(reac.emoji) == "👍":
+        reaction, _ = await self.bot.wait_for("reaction_add", check=check)
+        if str(reaction.emoji) == REACTIONS[0]:
             if not self.bot.data.get(str(message.author.id)):
                 self.bot.data[str(message.author.id)] = []
 
@@ -130,17 +132,17 @@ class TODOCog(commands.Cog):
         よろしいですか？
         """
         msg = await ctx.send(textwrap.dedent(text))
-        await msg.add_reaction("👍")
-        await msg.add_reaction("👎")
+        await msg.add_reaction(REACTIONS[0])
+        await msg.add_reaction(REACTIONS[1])
 
         def check(reaction, user):
             if not user == ctx.author: return
             if not reaction.message == msg: return
-            if not str(reaction.emoji) in ["👍", "👎"]: return
+            if not str(reaction.emoji) in REACTIONS: return
             return True
 
         reaction, _ = await self.bot.wait_for("reaction_add", check=check)
-        if str(reaction.emoji) == "👎":
+        if str(reaction.emoji) == REACTIONS[1]:
             await msg.delete()
             return await ctx.send("> todoリクエストをキャンセルしました。", delete_after=5)
 

--- a/cogs/todo.py
+++ b/cogs/todo.py
@@ -4,6 +4,8 @@ import numpy
 import textwrap
 
 REACTIONS = ["👍", "👎"]
+REACTION_YES = "👍"
+REACTION_NO = "👎"
 
 
 class TODOCog(commands.Cog):
@@ -61,8 +63,8 @@ class TODOCog(commands.Cog):
             msg += f"{todo}\n"
         msg += "\nTODOに追加しますか？"
         msg = await message.channel.send(msg)
-        await msg.add_reaction(REACTIONS[0])
-        await msg.add_reaction(REACTIONS[1])
+        for reaction in REACTIONS:
+            await msg.add_reaction(reaction)
 
         def check(reaction, user):
             if not user == message.author:
@@ -72,7 +74,7 @@ class TODOCog(commands.Cog):
             return True
 
         reaction, _ = await self.bot.wait_for("reaction_add", check=check)
-        if str(reaction.emoji) == REACTIONS[0]:
+        if str(reaction.emoji) == REACTION_YES:
             if not self.bot.data["todo"].get(str(message.author.id)):
                 self.bot.data["todo"][str(message.author.id)] = []
 
@@ -134,8 +136,8 @@ class TODOCog(commands.Cog):
         よろしいですか？
         """
         msg = await ctx.send(textwrap.dedent(text))
-        await msg.add_reaction(REACTIONS[0])
-        await msg.add_reaction(REACTIONS[1])
+        for reaction in REACTIONS:
+            await msg.add_reaction(reaction)
 
         def check(reaction, user):
             if not user == ctx.author: return
@@ -144,7 +146,7 @@ class TODOCog(commands.Cog):
             return True
 
         reaction, _ = await self.bot.wait_for("reaction_add", check=check)
-        if str(reaction.emoji) == REACTIONS[1]:
+        if str(reaction.emoji) == REACTION_NO:
             await msg.delete()
             return await ctx.send("> todoリクエストをキャンセルしました。", delete_after=5)
 

--- a/cogs/todo.py
+++ b/cogs/todo.py
@@ -3,18 +3,18 @@ from discord.ext import commands
 import numpy
 import textwrap
 
-
 REACTIONS = ["👍", "👎"]
+
 
 class TODOCog(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
-    def _make_request(self, ctx, to_user, todo):
+    def _make_request(self, ctx, user_send_to, todo):
         req_id = numpy.base_repr(ctx.message.id, 36)
         data = {
             "author": ctx.author.id,
-            "to": to_user.id,
+            "to": user_send_to.id,
             "content": todo
         }
         self.bot.data["request"][req_id] = data
@@ -125,7 +125,7 @@ class TODOCog(commands.Cog):
     @request.command(aliases=["c"])
     async def create(self, ctx, member: discord.Member, *, todo):
         text = f"""\
-        >>> `{str(member)}`さんにtodoリクエストを送ります。
+        >>> `{member}`さんにtodoリクエストを送ります。
         内容:
         ・{todo}
 

--- a/cogs/todo.py
+++ b/cogs/todo.py
@@ -173,8 +173,14 @@ class TODOCog(commands.Cog):
         req_todo = self.bot.data["request"].get(req_id)
         if not req_todo:
             return await ctx.send("> そのIDのリクエストは存在しません。もう一度確認してください。")
-
-        confirm_msg = await ctx.send(f"リクエストを承認しますか？\n\n内容:\n・{req_todo.content}")
+        confirm_msg_text = f"""\
+        リクエストを承認しますか？
+        承認する場合{REACTION_YES}を、拒否する場合{REACTION_NO}を押してください。
+        
+        内容:
+        ・{req_todo.content}
+        """
+        confirm_msg = await ctx.send(textwrap.dedent(confirm_msg_text))
         confirm = await self._wait_reaction(ctx, confirm_msg)
         if not confirm:
             await confirm_msg.delete()

--- a/cogs/todo.py
+++ b/cogs/todo.py
@@ -45,7 +45,7 @@ class TODOCog(commands.Cog):
         if not message.content.startswith("TODO:"):
             return
 
-        s = message.content.split("\n")
+        s = message.content.splitlines()
         if len(s) < 2:
             return
         todos = s[1:]

--- a/cogs/todo.py
+++ b/cogs/todo.py
@@ -2,6 +2,7 @@ import discord
 from discord.ext import commands
 import json
 import hashlib
+import numpy
 
 
 class TODOCog(commands.Cog):
@@ -9,16 +10,15 @@ class TODOCog(commands.Cog):
         self.bot = bot
 
     def make_request(self, ctx, to_user, todo):
-        text = f"{ctx.message.id} - {ctx.author.id} -> {to_user.id}"
-        hashed = hashlib.sha256(text.encode()).hexdigest()
+        req_id = numpy.base_repr(ctx.message.id, 36)
         data = {
             "author": ctx.author.id,
             "to": to_user.id,
             "content": todo
         }
-        self.bot.data["request"][hashed[:10]] = data
+        self.bot.data["request"][req_id] = data
         self.bot.save_data()
-        return hashed[:10]
+        return req_id
 
     @commands.command(name="help")
     async def _help(self, ctx):

--- a/cogs/todo.py
+++ b/cogs/todo.py
@@ -178,7 +178,7 @@ class TODOCog(commands.Cog):
     @request.command(aliases=["a"])
     async def approve(self, ctx, req_id: str):
         req_todo = self.bot.data["request"].get(req_id)
-        if not req_id:
+        if not req_todo:
             return await ctx.send("> そのIDのリクエストは存在しません。もう一度確認してください。")
 
         self.bot.data["todo"][str(ctx.author.id)].append(req_todo.content)

--- a/cogs/todo.py
+++ b/cogs/todo.py
@@ -58,13 +58,13 @@ class TODOCog(commands.Cog):
 
         for i, todo in enumerate(todos):
             todos[i] = todo[2:]
-        msg = f"{message.author.mention}TODOが検出されました。\n\n>>> "
+        confirm_msg_text = f"{message.author.mention}TODOが検出されました。\n\n>>> "
         for todo in todos:
-            msg += f"{todo}\n"
-        msg += "\nTODOに追加しますか？"
-        msg = await message.channel.send(msg)
+            confirm_msg_text += f"{todo}\n"
+        confirm_msg_text += "\nTODOに追加しますか？"
+        confirm_msg = await message.channel.send(confirm_msg_text)
         for reaction in REACTIONS:
-            await msg.add_reaction(reaction)
+            await confirm_msg.add_reaction(reaction)
 
         def check(reaction, user):
             if not user == message.author:

--- a/cogs/todo.py
+++ b/cogs/todo.py
@@ -151,7 +151,7 @@ class TODOCog(commands.Cog):
 とコマンドを実行してください。"""
         try:
             await member.send(dm_msg)
-        except:
+        except discord.Forbidden:
             await ctx.send(f"{member.mention}\n" + dm_msg)
 
         result = f"""
@@ -179,9 +179,9 @@ class TODOCog(commands.Cog):
 
         del self.bot.data["request"][req_id]
         self.bot.save_data()
-        return await ctx.send(f"> リクエストを拒否しました。")
+        return await ctx.send("> リクエストを拒否しました。")
 
 
 def setup(bot):
     bot.add_cog(TODOCog(bot))
-    print("todocog loaded")
+    print("TODOCog loaded")

--- a/cogs/todo.py
+++ b/cogs/todo.py
@@ -73,11 +73,11 @@ class TODOCog(commands.Cog):
 
         reaction, _ = await self.bot.wait_for("reaction_add", check=check)
         if str(reaction.emoji) == REACTIONS[0]:
-            if not self.bot.data.get(str(message.author.id)):
-                self.bot.data[str(message.author.id)] = []
+            if not self.bot.data["todo"].get(str(message.author.id)):
+                self.bot.data["todo"][str(message.author.id)] = []
 
             for todo in todos:
-                self.bot.data[str(message.author.id)].append(todo)
+                self.bot.data["todo"][str(message.author.id)].append(todo)
                 self.bot.save_data()
             await message.channel.send(">>> 正常にTODOに追加されました。\n一覧を見るには`todo!list`")
             await msg.delete()
@@ -86,12 +86,12 @@ class TODOCog(commands.Cog):
 
     @commands.command(name="list", aliases=["l"])
     async def _list(self, ctx):
-        l = self.bot.data.get(str(ctx.author.id))
+        todo_list = self.bot.data["todo"].get(str(ctx.author.id))
         todos = ""
-        if not l:
+        if not todo_list:
             return await ctx.send(f">>> {ctx.author.mention}のTODOリスト\n\nNone")
 
-        for i, todo in enumerate(l):
+        for i, todo in enumerate(todo_list):
             todos += f"{i}: {todo}" + "\n"
         todos = todos.rstrip("\n")
         msg = f">>> {ctx.author.mention}のTODOリスト\n\n" + todos
@@ -99,12 +99,12 @@ class TODOCog(commands.Cog):
 
     @commands.command(aliases=["d"])
     async def delete(self, ctx, num: int):
-        l = self.bot.data.get(str(ctx.author.id))
-        if not l:
+        todo_list = self.bot.data["todo"].get(str(ctx.author.id))
+        if not todo_list:
             return await ctx.send("> そのTODOはありません。`todo!list`で確認してください。")
         try:
-            deleted_todo = self.bot.data[str(ctx.author.id)][num]
-            del self.bot.data[str(ctx.author.id)][num]
+            deleted_todo = self.bot.data["todo"][str(ctx.author.id)][num]
+            del self.bot.data["todo"][str(ctx.author.id)][num]
         except IndexError:
             return await ctx.send("> そのTODOはありません。`todo!list`で確認してください。")
         self.bot.save_data()
@@ -124,6 +124,8 @@ class TODOCog(commands.Cog):
 
     @request.command(aliases=["c"])
     async def create(self, ctx, member: discord.Member, *, todo):
+        if not todo:
+            return await ctx.send("> 引数に送りたいTODOを指定してください。")
         text = f"""\
         >>> `{member}`さんにtodoリクエストを送ります。
         内容:
@@ -184,7 +186,6 @@ class TODOCog(commands.Cog):
 
     @request.command(aliases=["d"])
     async def deny(self, ctx, req_id: str):
-        req_todo = self.bot.data["request"].get(req_id)
         if not req_id:
             return await ctx.send("> そのIDのリクエストは存在しません。もう一度確認してください。")
 

--- a/cogs/todo.py
+++ b/cogs/todo.py
@@ -60,13 +60,14 @@ class TODOCog(commands.Cog):
         msg = await message.channel.send(msg)
         await msg.add_reaction("👍")
         await msg.add_reaction("👎")
+
         def check(reac, user):
             if not user == message.author:
                 return False
             if not str(reac.emoji) in ["👍", "👎"]:
                 return False
             return True
-        
+
         reac, _ = await self.bot.wait_for("reaction_add", check=check)
         if str(reac.emoji) == "👍":
             if not self.bot.data.get(str(message.author.id)):
@@ -105,7 +106,7 @@ class TODOCog(commands.Cog):
             return await ctx.send("> そのTODOはありません。`todo!list`で確認してください。")
         self.bot.save_data()
         return await ctx.send(f"> TODO`{deleted_todo}`の削除に成功しました。")
-    
+
     @delete.error
     async def error_delete(self, ctx, err):
         if isinstance(err, commands.errors.BadArgument):
@@ -124,11 +125,13 @@ class TODOCog(commands.Cog):
         msg = await ctx.send(text)
         await msg.add_reaction("👍")
         await msg.add_reaction("👎")
+
         def check(reac, user):
             if not user == ctx.author: return
             if not reac.message == msg: return
             if not str(reac.emoji) in ["👍", "👎"]: return
             return True
+
         reac, _ = await self.bot.wait_for("reaction_add", check=check)
         if str(reac.emoji) == "👎":
             await msg.delete()
@@ -143,15 +146,40 @@ class TODOCog(commands.Cog):
 
 リクエストID: `{req_id}`
 
-このリクエストを承認する場合は`todo!request_applove {req_id}`
+このリクエストを承認する場合は`todo!request_approve {req_id}`
 拒否する場合は`todo!request_deny {req_id}`
 とコマンドを実行してください。"""
         try:
             await member.send(dm_msg)
         except:
             await ctx.send(f"{member.mention}\n" + dm_msg)
-        
-        #TODO: 取得したIDを送信「受付完了」
+
+        result = f"""
+>>> リクエストの送信に成功しました。
+
+リクエストID: `{req_id}`"""
+        return await ctx.send(result)
+
+    @commands.command()
+    async def request_approve(self, ctx, req_id: str):
+        req_todo = self.bot.data["request"].get(req_id)
+        if not req_id:
+            return await ctx.send("> そのIDのリクエストは存在しません。もう一度確認してください。")
+
+        self.bot.data["todo"][str(ctx.author.id)].append(req_todo.content)
+        del self.bot.data["request"][req_id]
+        self.bot.save_data()
+        return await ctx.send(f"> リクエストを承認しました。\n\n追加されたTODO:\n・{req_todo.content}")
+
+    @commands.command()
+    async def request_deny(self, ctx, req_id: str):
+        req_todo = self.bot.data["request"].get(req_id)
+        if not req_id:
+            return await ctx.send("> そのIDのリクエストは存在しません。もう一度確認してください。")
+
+        del self.bot.data["request"][req_id]
+        self.bot.save_data()
+        return await ctx.send(f"> リクエストを拒否しました。")
 
 
 def setup(bot):


### PR DESCRIPTION
色々間違えたのでやり直しPRです
- Command `request`
  - 第1引数にTODOリクエストを送りたいユーザーのメンション or ID or 名前を指定
  - 第2引数(可変)に送りたいTODO文字列を指定
  - リクエストは送り先のユーザーのDMに送られる
  - リクエストごとにIDが作成される(sha256)
  - IDを使い後述のコマンドでリクエストの承認, 拒否を行う
-  Command `request_approve`
  - 第1引数にリクエストIDを指定
  - 指定されたIDに対応するTODOリクエストを承認, 自身のTODOリストに追加する
- Command `request_deny`
  - 第1引数にリクエストIDを指定
  - 指定されたIDに対応するTODOリクエストを拒否

※リクエスト承認, 拒否はリクエストをしたユーザーには通知されない, 今後通知されるよう改善する可能性あり